### PR TITLE
[Fix #10] Relaxed dependent Gem versions in Gemspec.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     gems-cli (0.1.4)
-      clipboard (= 1.0.5)
-      gems (= 0.8.3)
-      gli (= 2.12.2)
-      highline (= 1.6.21)
-      rainbow (= 2.0.0)
-      will_paginate (= 3.0.7)
+      clipboard (~> 1.0, >= 1.0.5)
+      gems (~> 0.8, >= 0.8.3)
+      gli (~> 2.12, >= 2.12.2)
+      highline (~> 1.6, >= 1.6.21)
+      rainbow (~> 2.0, >= 2.0.0)
+      will_paginate (~> 3.0, >= 3.0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -18,7 +18,7 @@ GEM
     gli (2.12.2)
     highline (1.6.21)
     rainbow (2.0.0)
-    rake (10.3.2)
+    rake (10.4.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -39,6 +39,6 @@ PLATFORMS
 
 DEPENDENCIES
   gems-cli!
-  rake (~> 10.3.2)
-  rspec (~> 3.1.0)
-  yard (~> 0.8.7.6)
+  rake (~> 10.4, >= 10.4.2)
+  rspec (~> 3.1)
+  yard (~> 0.8, >= 0.8.7.6)

--- a/gems-cli.gemspec
+++ b/gems-cli.gemspec
@@ -17,14 +17,14 @@ spec = Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
   s.post_install_message = "Thanks for installing! \ngems-cli usage: `gems s chase`"
 
-  s.add_development_dependency 'rake', '~> 10.3.2'
-  s.add_development_dependency 'rspec', '~> 3.1.0'
-  s.add_development_dependency 'yard', '~> 0.8.7.6'
+  s.add_development_dependency 'rake', '~> 10.4', '>= 10.4.2'
+  s.add_development_dependency 'rspec', '~> 3.1' # '>= 3.1.0' would be redundant
+  s.add_development_dependency 'yard', '~> 0.8', '>= 0.8.7.6'
 
-  s.add_runtime_dependency 'gli','2.12.2'
-  s.add_runtime_dependency 'gems','0.8.3'
-  s.add_runtime_dependency 'highline', '1.6.21'
-  s.add_runtime_dependency 'clipboard', '1.0.5'
-  s.add_runtime_dependency 'rainbow', '2.0.0'
-  s.add_runtime_dependency 'will_paginate', '3.0.7'
+  s.add_runtime_dependency 'gli', '~> 2.12', '>= 2.12.2'
+  s.add_runtime_dependency 'gems', '~> 0.8', '>= 0.8.3'
+  s.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.21'
+  s.add_runtime_dependency 'clipboard', '~> 1.0', '>= 1.0.5'
+  s.add_runtime_dependency 'rainbow', '~> 2.0', '>= 2.0.0'
+  s.add_runtime_dependency 'will_paginate', '~> 3.0', '>= 3.0.3'
 end


### PR DESCRIPTION
...while maintaining now-current dependency versions. A bit of future-proofing.

RSpec: 13 examples, 0 failures (as of Commit 123c2277)
(No coverage or style-compliance checking yet.)